### PR TITLE
Fix Contact Section for Non-logged in users

### DIFF
--- a/includes/plaintext.php
+++ b/includes/plaintext.php
@@ -8,6 +8,7 @@
 class WP_Resume_Plaintext {
 
 	private $parent;
+	public $author_id;
 
 	/**
 	 * Register Init Hook
@@ -16,6 +17,7 @@ class WP_Resume_Plaintext {
 	function __construct( &$parent ) {
 
 		$this->parent = $parent;
+		$this->author_id = &$parent->author_id;
 
 		add_action( 'parse_query', array( &$this, 'init' ) );
 	}
@@ -54,7 +56,7 @@ class WP_Resume_Plaintext {
 	function contact_info( $author = null ) {
 
 		$author = $this->parent->get_author( $author );
-		$contact_info = $this->parent->options->get_user_option( 'contact_info', $author );
+		$contact_info = $this->parent->options->get_user_option( 'contact_info', $this->author_id);
 
 		array_walk_recursive( $contact_info, array( &$this, 'contact_info_walker' ) );
 

--- a/wp-resume.php
+++ b/wp-resume.php
@@ -253,7 +253,7 @@ class WP_Resume extends Plugin_Boilerplate_v_1 {
 			$author = $user->user_nicename;
 		}
 
-		$this->author_id = $user->id;
+		$this->author_id = get_the_author_meta('ID');
 		$this->author = $author;
 
 		//get all sections ordered by term_id (order added)
@@ -749,7 +749,7 @@ class WP_Resume extends Plugin_Boilerplate_v_1 {
 		//determine author and set as global so templates can read
 		$this->author = $this->get_author( $atts );
         $user = get_user_by('slug', $this->author);
-        $this->author_id = $user->id; 
+        $this->author_id = get_the_author_meta('ID'); 
 
 		//allow shortcode to accept section argument
 		$section = $this->get_section( $atts );
@@ -988,7 +988,7 @@ class WP_Resume extends Plugin_Boilerplate_v_1 {
             $user = get_userdata('slag', $this->author);
 
 		}
-        $this->author_id = $user->id;
+        $this->author_id = get_the_author_meta('ID');
 		$this->author = $this->api->apply_filters( 'author', $this->author );
 
 		return $this->author;


### PR DESCRIPTION
I've changed the Author_ID lookup to use the author ID of author matching the page or post containing the resume. Before this change-set the plugin wouldn't display the author information block from the option page when the user wasn't cookied or logged in to the site.
