### PR TITLE
Dates

### DIFF
--- a/includes/templating.php
+++ b/includes/templating.php
@@ -214,7 +214,7 @@ class WP_Resume_Templating {
 			
 			//if the position is current, append todays date to span
 			else if ( $value == 'Present' )
-				$date .= '<time datetime="' . date( 'Y-m-d' ) . ' title="' . date( 'Y-m-d' ) . '">';
+				$date .= '<time datetime="' . date( 'Y-m-d' ) . '" title="' . date( 'Y-m-d' ) . '">';
 				
 			//if we can't parse the date, just output a standard span
 			else

--- a/includes/templating.php
+++ b/includes/templating.php
@@ -182,6 +182,32 @@ class WP_Resume_Templating {
 
 
 	/**
+	 * Return true iff date is valid value for an HTML <time> element
+	 * representing a date (with no time nor timezone).
+	 * See https://html.spec.whatwg.org/multipage/semantics.html#the-time-element
+	 *
+	 * @param string $date the date as stored in post_meta
+	 * @return true if date is in a valid format, else false
+	 */
+	function is_valid_html_date( $date ) {
+
+		$patterns = array(
+			'\d\d\d\d',
+			'\d\d\d\d-\d\d',
+			'\d\d\d\d-\d\d-\d\d',
+			'\d\d\d\d-W\d\d',
+			'\d\d-\d\d',
+		);
+
+		foreach( $patterns as $pattern )
+			if ( preg_match( '/\A' . $pattern . '\z/', $date ))
+				return true;
+
+		return false;
+	}
+
+
+	/**
 	 * Function used to parse the date meta and move to human-readable format
 	 * 
 	 * Both from and to are option, and if both are present, will be joined by an &ndash;
@@ -200,35 +226,40 @@ class WP_Resume_Templating {
 			
 			$value = get_post_meta( $ID, "wp_resume_{$field}", true );
 			$itemprop = ( $class = 'dtstart' ) ? 'startDate' : 'endDate';
+			$use_markup = true;
 
 			//we don't have this field, skip
 			if ( !$value)
 				continue;
 			
-			//to ensure compliance with hResume format, span should reflect ability to parse date
+			//to ensure compliance with hResume format, markup should reflect ability to parse date
 			//@link https://github.com/benbalter/WP-Resume/issues/7
 			
-		// Don't output a 'datetime' attribute. (This worked correctly
-		// only when a specific day is given, whereas a month or year
-		// is usually given for a resume position.)
-		//	
-		//	//if we can parse the date, append the proper class and formatted date to span
-		//	if ( strtotime( $value ) ) 
+			//if a valid HTML-format date, wrap in a <time> element with no 'datetime' attr.
+			if ( $this->is_valid_html_date( $value ) )
+				$date .= '<time itemprop="' . $itemprop . '" class="' . $class . '">';
+
+		//	//if we can parse the date, append the proper class and formatted date
+		//	//### Ignores the specified precision (year vs. month vs. day) and
+		//	//### writes '01' for a missing month or day, which is misleading.
+		//	else if ( strtotime( $value ) )
 		//		$date .= '<time itemprop="' . $itemprop . '" class="' . $class . '" datetime="' . date( 'Y-m-d', strtotime( $value ) ) . '">';
 		//	
-		//	//if the position is current, append todays date to span
+		//	//if the position is current, mark up as today's date
+		//	//### Omits microformats mark-up.
+		//	//### Doesn't recognise alternative words/spellings/languages.
+		//	//### I don't like 'now' being converted to a specific date.
 		//	else if ( $value == 'Present' )
 		//		$date .= '<time datetime="' . date( 'Y-m-d' ) . '">';
 		//		
-		//	//if we can't parse the date, just output a standard span
-		//	else
-		//		$date .= '<time>';
-		//	
-			$date .= '<time>';
+			//if we can't parse the date, don't mark it up
+			else
+				$use_markup = false;
 	
 			$date .= $this->parent->api->apply_filters( 'date', $value, $field );
 			
-			$date .= '</time>';		
+			if ( $use_markup )
+				$date .= '</time>';
 			
 			//this is the from field and there is a to field, append the dash
 			//it's okay that we're calling get_post_meta twice on "to" because it's cached automatically

--- a/includes/templating.php
+++ b/includes/templating.php
@@ -210,11 +210,11 @@ class WP_Resume_Templating {
 			
 			//if we can parse the date, append the proper class and formatted date to span
 			if ( strtotime( $value ) ) 
-				$date .= '<time itemprop="' . $itemprop . '" class="' . $class . '" datetime="' . date( 'Y-m-d', strtotime( $value ) ) . '" title="' . date( 'Y-m-d', strtotime( $value ) ) . '">';
+				$date .= '<time itemprop="' . $itemprop . '" class="' . $class . '" datetime="' . date( 'Y-m-d', strtotime( $value ) ) . '">';
 			
 			//if the position is current, append todays date to span
 			else if ( $value == 'Present' )
-				$date .= '<time datetime="' . date( 'Y-m-d' ) . '" title="' . date( 'Y-m-d' ) . '">';
+				$date .= '<time datetime="' . date( 'Y-m-d' ) . '">';
 				
 			//if we can't parse the date, just output a standard span
 			else

--- a/includes/templating.php
+++ b/includes/templating.php
@@ -208,17 +208,23 @@ class WP_Resume_Templating {
 			//to ensure compliance with hResume format, span should reflect ability to parse date
 			//@link https://github.com/benbalter/WP-Resume/issues/7
 			
-			//if we can parse the date, append the proper class and formatted date to span
-			if ( strtotime( $value ) ) 
-				$date .= '<time itemprop="' . $itemprop . '" class="' . $class . '" datetime="' . date( 'Y-m-d', strtotime( $value ) ) . '">';
-			
-			//if the position is current, append todays date to span
-			else if ( $value == 'Present' )
-				$date .= '<time datetime="' . date( 'Y-m-d' ) . '">';
-				
-			//if we can't parse the date, just output a standard span
-			else
-				$date .= '<time>';
+		// Don't output a 'datetime' attribute. (This worked correctly
+		// only when a specific day is given, whereas a month or year
+		// is usually given for a resume position.)
+		//	
+		//	//if we can parse the date, append the proper class and formatted date to span
+		//	if ( strtotime( $value ) ) 
+		//		$date .= '<time itemprop="' . $itemprop . '" class="' . $class . '" datetime="' . date( 'Y-m-d', strtotime( $value ) ) . '">';
+		//	
+		//	//if the position is current, append todays date to span
+		//	else if ( $value == 'Present' )
+		//		$date .= '<time datetime="' . date( 'Y-m-d' ) . '">';
+		//		
+		//	//if we can't parse the date, just output a standard span
+		//	else
+		//		$date .= '<time>';
+		//	
+			$date .= '<time>';
 	
 			$date .= $this->parent->api->apply_filters( 'date', $value, $field );
 			

--- a/includes/templating.php
+++ b/includes/templating.php
@@ -245,13 +245,6 @@ class WP_Resume_Templating {
 		//	else if ( strtotime( $value ) )
 		//		$date .= '<time itemprop="' . $itemprop . '" class="' . $class . '" datetime="' . date( 'Y-m-d', strtotime( $value ) ) . '">';
 		//	
-		//	//if the position is current, mark up as today's date
-		//	//### Omits microformats mark-up.
-		//	//### Doesn't recognise alternative words/spellings/languages.
-		//	//### I don't like 'now' being converted to a specific date.
-		//	else if ( $value == 'Present' )
-		//		$date .= '<time datetime="' . date( 'Y-m-d' ) . '">';
-		//		
 			//if we can't parse the date, don't mark it up
 			else
 				$use_markup = false;


### PR DESCRIPTION
This improves (in my opinion) the markup of start and end dates for each position.

It no longer converts a year-only date to year-01-01, or a year-and-month date to a year-month-01, as I felt that was ugly. Instead, if the date is already specified in a recognised HTML `<time>` format (such as YYYY[-MM[-DD]] or a couple of others -- see https://html.spec.whatwg.org/multipage/semantics.html#the-time-element) then it marks it up (without a 'datetime' attribute), else it doesn't.

It removes redundancy in the `<time>` element. (1) It omits 'datetime' attribute when the `<time>` element's content is already in a valid format. (2) It omits the 'title' attribute, which seems to be a hang-over from when `<abbr>` was used. The 'title' attribute was causing Firefox to display the date as a tooltip when hovered, which might be useful for debugging but in real life was an unnecessary distraction.

I didn't like 'Present' (this exact spelling only) being marked up as the specific date of today (at the time of rendering the page), so I removed that. The markup for 'Present' also contained an HTML syntax error (missing quote) which I fixed in the first commit in this branch.

What's missing is a way to mark up a dates entered for display in other formats. For example, "1995 to March 2012" was previously marked up with '1995-01-01' and '2012-03-01', and is now marked up with '1995' for the start date (definitely better) but no mark-up for the end date (arguably better or worse than before).
